### PR TITLE
Update truffle.js

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -19,4 +19,9 @@ module.exports = {
       network_id: '3',
     },
   },
+  compilers: {
+    solc: {
+      version: '0.4.25'    // Fetch exact version from solc-bin (default: truffle's version)
+    }
+  }
 }


### PR DESCRIPTION
The contracts seem to require pre-5 solc (truffle compile step of https://github.com/graphprotocol/ethdenver-dapp fails otherwise)