### PR TITLE
Add docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+  graph-node:
+    image: graphprotocol/graph-node:v0.22.0
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+      - '8020:8020'
+      - '8030:8030'
+      - '8040:8040'
+    depends_on:
+      - ipfs
+      - postgres
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: 'ipfs:5001'
+      # Change next line if you want to connect to a different JSON-RPC endpoint
+      ethereum: 'mainnet:http://host.docker.internal:8545'
+      RUST_LOG: info # up until v0.22.0
+      GRAPH_LOG: info
+  ipfs:
+    image: ipfs/go-ipfs:v0.4.23
+    ports:
+      - '5001:5001'
+    volumes:
+      - ./data/ipfs:/data/ipfs
+  postgres:
+    image: postgres
+    ports:
+      - '5432:5432'
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       ipfs: 'ipfs:5001'
       # Change next line if you want to connect to a different JSON-RPC endpoint
       ethereum: 'mainnet:http://host.docker.internal:8545'
-      RUST_LOG: info # up until v0.22.0
       GRAPH_LOG: info
   ipfs:
     image: ipfs/go-ipfs:v0.4.23


### PR DESCRIPTION
I think it makes sense to put the main docker-compose file here into the example repo so we can point the subgraph-devs here. It is slightly different to the one in @graphprotocol/graph-node, more focussed on subgraph development.