### PR TITLE
Bump graph-ts version for yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.20.1",
-    "@graphprotocol/graph-ts": "^0.20.0"
+    "@graphprotocol/graph-ts": "^0.20.1"
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
Going through the docs, `graph --init --from-example` was throwing error on yarn install. Resolved through upgrading graph-ts version in package.json.

Related Issue:
https://github.com/graphprotocol/graph-ts/issues/113