### PR TITLE
Fix IPFS `localhost` issue on some IPv6-enabled systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build/
+generated/
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy": "graph deploy example --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
+    "deploy-local": "graph deploy example --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.23.2",


### PR DESCRIPTION
When attempting to connect to IPFS via `localhost:5001`, it resolves to `::1` on (all? Most? Not sure) IPv6-enabled systems. I've had this issue myself when trying out `example-subgraph` for the first time and other team members have as well, so let's fix this  :smile: 

@Jannis