### PR TITLE
Update Gravity.sol to fix the minimum EVM version

### DIFF
--- a/contracts/Gravity.sol
+++ b/contracts/Gravity.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.21;
 
 contract GravatarRegistry {
   event NewGravatar(uint id, address owner, string displayName, string imageUrl);


### PR DESCRIPTION
Following https://ethereum.stackexchange.com/questions/51124/parsererror-expected-token-semicolon-got-lparen advice.

After updating the minimum EVM version the compilation works again.